### PR TITLE
fix: production ci sentry patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,7 @@ jobs:
           npm run build:${{ inputs.build-env }}
           echo sentry release:
           echo tug-website@${{ github.sha }}
-          if ["${{ secrets.SENTRY_TOKEN }}" != ""]; then
-                    echo "sentry token exists"
-            echo WOOHOO
-          fi
+          echo ${{ secrets.SENTRY_TOKEN }}
 
         env:
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       build-env:
         required: true
         type: string
+    secrets:
+      SENTRY_TOKEN:
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,15 @@ jobs:
           key: ${{ runner.os }}-${{ inputs.build-env }}
 
       - name: Build for ${{ inputs.build-env }}
-        run: npm run build:${{ inputs.build-env }}
+        run: |
+          npm run build:${{ inputs.build-env }}
+          echo sentry release:
+          echo tug-website@${{ github.sha }}
+          if ["${{ secrets.SENTRY_TOKEN }}" != ""]; then
+                    echo "sentry token exists"
+            echo WOOHOO
+          fi
+
         env:
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
           SENTRY_RELEASE: tug-website@${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm run build:${{ inputs.build-env }}
         env:
           SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
-          SENTRY_RELEASE: tug-website@${GITHUB_SHA}
+          SENTRY_RELEASE: tug-website@${{ github.sha }}
   
       - name: Copy locales
         run: npm run copy:locales

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       build-env: preview
+    secrets:
+      SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
 
   build-production:
     needs: [ verify ]
@@ -23,6 +25,8 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       build-env: production
+    secrets:
+      SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
 
   deploy-preview:
     needs: [ build-preview ]


### PR DESCRIPTION
Did a quick fix. Seems like at least in the preview ci, sentry token and release name are properly configured. 