### PR TITLE
fix: disable experimental feature 'outputStandalone' on Windows

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,10 @@ const { withSentryConfig } = require('@sentry/nextjs');
 
 const { i18n } = require('./next-i18next.config');
 
+const os = require('os');
+const platform = os.platform();
+const outputStandaloneEnable = platform === 'win32' ? false : true;
+
 const unifyNodeModules = (names) =>
   names.reduce(
     (acc, name) => ({
@@ -44,7 +48,7 @@ const config = {
    * for building the docker image
    */
   experimental: {
-    outputStandalone: true,
+    outputStandalone: outputStandaloneEnable,
   },
 
   // https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config


### PR DESCRIPTION
Disable experimental feature 'outputStandalone' when OS is windows because the current version has some BUGs when building standalone dist file

![image](https://user-images.githubusercontent.com/11588555/176817503-218e47f2-317c-4e09-8666-5f75e7f83c4c.png)
